### PR TITLE
Valid object checks

### DIFF
--- a/Transitions/Platforms/Android/ChangeAlpha.cs
+++ b/Transitions/Platforms/Android/ChangeAlpha.cs
@@ -30,7 +30,11 @@ namespace OliveTree.Transitions.Droid
             if (start == end) return null;
 
             var anim = ValueAnimator.OfFloat(start, end);
-            anim.Update += (_, args) => view.Alpha = (float)args.Animation.AnimatedValue;
+            anim.Update += (_, args) =>
+            {
+                if (view.IsDisposed()) return;
+                view.Alpha = (float) args.Animation.AnimatedValue;
+            };
 
             return anim;
         }

--- a/Transitions/Platforms/Android/ChangeBounds.cs
+++ b/Transitions/Platforms/Android/ChangeBounds.cs
@@ -12,8 +12,7 @@ namespace OliveTree.Transitions.Droid
 
         public ChangeBounds(TransitionBase transition)
         {
-            if (transition == null) throw new ArgumentNullException(nameof(transition));
-            _transition = transition;
+            _transition = transition ?? throw new ArgumentNullException(nameof(transition));
         }
 
         public ChangeBounds(IntPtr ptr, JniHandleOwnership own) : base(ptr, own) { }

--- a/Transitions/Platforms/Android/DelayedTransition.cs
+++ b/Transitions/Platforms/Android/DelayedTransition.cs
@@ -11,8 +11,7 @@ namespace OliveTree.Transitions.Droid
         protected DelayedTransition(IntPtr ptr, JniHandleOwnership own) : base(ptr, own) { }
         protected DelayedTransition(TransitionBase transition)
         {
-            if (transition == null) throw new ArgumentNullException(nameof(transition));
-            _transition = transition;
+            _transition = transition ?? throw new ArgumentNullException(nameof(transition));
         }
 
         public override ITimeInterpolator Interpolator => _transition.GetInterpolator();

--- a/Transitions/Platforms/Android/Transition.cs
+++ b/Transitions/Platforms/Android/Transition.cs
@@ -87,16 +87,14 @@ namespace OliveTree.Transitions.Droid
 
             public TransitionCompletion(Transition transition, View container)
             {
-                if (transition == null) throw new ArgumentNullException(nameof(transition));
-                if (container == null) throw new ArgumentNullException(nameof(container));
-                _transition = transition;
-                _container = container;
+                _transition = transition ?? throw new ArgumentNullException(nameof(transition));
+                _container = container ?? throw new ArgumentNullException(nameof(container));
             }
 
             public void OnTransitionStart(Android.Transitions.Transition transition)
             {
                 _startingType = _container.LayerType;
-                if (_startingType != LayerType.Hardware)
+                if (_startingType != LayerType.Hardware && !_container.IsDisposed())
                     _container.SetLayerType(LayerType.Hardware, null);
             }
 
@@ -107,7 +105,7 @@ namespace OliveTree.Transitions.Droid
             public void OnTransitionEnd(Android.Transitions.Transition transition) => Cleanup();
             private void Cleanup()
             {
-                if (_startingType != LayerType.Hardware)
+                if (_startingType != LayerType.Hardware && !_container.IsDisposed())
                     _container.SetLayerType(_startingType, null);
                 _transition.Completed?.Invoke(_transition, EventArgs.Empty);
             }

--- a/Transitions/Platforms/Android/ViewExtensions.cs
+++ b/Transitions/Platforms/Android/ViewExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Android.Views;
+
+namespace OliveTree.Transitions.Droid
+{
+    internal static class ViewExtensions
+    {
+        public static bool IsDisposed(this View view) => !view.PeerReference.IsValid;
+    }
+}

--- a/Transitions/Platforms/iOS/TransitionBase.cs
+++ b/Transitions/Platforms/iOS/TransitionBase.cs
@@ -38,12 +38,12 @@ namespace OliveTree.Transitions.iOS
         private void OnTransitioning(object sender, bool transitioning)
         {
             var r = Renderer;
-            if (r == null) return;
+            if (r == null || r.IsDisposed()) return;
 
             if (transitioning)
             {
                 /* TODO - it would appear that to customize easing (and have it per-transition) we need to:
-                 *      1. Implement Began/Ending on each transition to configure a CAAnimation
+                 *      1. Implement Begin/Ending on each transition to configure a CAAnimation
                  *      2. Add animations to the layer in Began (before the property has changed)
                  *      3. Remove the UIView.Begin/Commit code from here.
                  */

--- a/Transitions/Platforms/iOS/UIViewExtensions.cs
+++ b/Transitions/Platforms/iOS/UIViewExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using UIKit;
+
+namespace OliveTree.Transitions.iOS
+{
+    internal static class UIViewExtensions
+    {
+        public static bool IsDisposed(this UIView uiView) => uiView.Handle == IntPtr.Zero;
+    }
+}

--- a/Transitions/Transitions.csproj
+++ b/Transitions/Transitions.csproj
@@ -72,7 +72,6 @@
       <ItemGroup>
         <Reference Include="System" />
         <Reference Include="System.Core" />
-        <Reference Include="System.Runtime" />
         <Reference Include="System.Runtime.Serialization" />
         <Reference Include="System.Xml" />
         <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Adding checks if the native references have been disposed or not created yet. We don't actually know the difference between these cases since all we can check is whether we have a valid pointer.